### PR TITLE
Upgrade to PureScript 0.10.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,14 +23,14 @@
   },
   "license": "MIT",
   "dependencies": {
-    "purescript-argonaut-core": "^1.0.0",
-    "purescript-arrays": "^1.0.0",
-    "purescript-generics": "^1.0.0",
-    "purescript-integers": "^1.0.0",
+    "purescript-argonaut-core": "^2.0.1",
+    "purescript-arrays": "^3.1.0",
+    "purescript-generics": "^3.1.0",
+    "purescript-integers": "^2.1.0",
     "purescript-partial": "^1.1.2"
   },
   "devDependencies": {
-    "purescript-strongcheck-generics": "^0.4.0",
-    "purescript-assert": "^1.0.0"
+
+    "purescript-assert": "^2.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
     "purescript-partial": "^1.1.2"
   },
   "devDependencies": {
-
+    "purescript-strongcheck-generics": "parsonsmatt/purescript-strongcheck-generics#4abd959aca4c5ae9495b030d360e4e3fc1567861",
     "purescript-assert": "^2.0.0"
   }
 }

--- a/src/Data/Argonaut/Generic/Aeson.purs
+++ b/src/Data/Argonaut/Generic/Aeson.purs
@@ -24,7 +24,6 @@ import Data.Generic (class Generic, DataConstructor, GenericSignature(SigProd), 
 import Data.List (List(..), fromFoldable)
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Traversable (sequence)
-import Data.Tuple (Tuple(Tuple))
 import Partial.Unsafe (unsafeCrashWith, unsafePartial)
 
 
@@ -96,8 +95,9 @@ decodeMaybe _ _ _ = Nothing
 encodeEither :: Options -> GenericSignature -> GenericSpine -> Maybe Json
 encodeEither opts (SigProd "Data.Either.Either" sigArr) (SProd eitherConstr [elem]) =
     pure
-      $ fromObject $ SM.fromList
-      $ Tuple strippedConstr (genericUserEncodeJson' opts valSig val) `Cons` Nil
+      $ fromObject 
+      $ SM.singleton strippedConstr 
+      $ genericUserEncodeJson' opts valSig val
   where
     strippedConstr = stripModulePath eitherConstr
     valSig = getSigFromUnaryConstructor sigArr eitherConstr

--- a/src/Data/Argonaut/Generic/Util.purs
+++ b/src/Data/Argonaut/Generic/Util.purs
@@ -5,7 +5,7 @@ import Data.Array (head, null, length)
 import Data.Foldable (all)
 import Data.Generic (GenericSignature(SigRecord), GenericSpine(SRecord), DataConstructor)
 import Data.Maybe (fromMaybe, Maybe(..))
-import Data.String (lastIndexOf, drop)
+import Data.String (lastIndexOf, drop, Pattern(..))
 
 allConstructorsNullary :: Array DataConstructor -> Boolean
 allConstructorsNullary = all (null <<< _.sigValues)
@@ -17,7 +17,7 @@ isUnaryRecord constrSigns = length constrSigns == 1 -- Only one constructor
 
 
 stripModulePath :: String -> String
-stripModulePath constr = case lastIndexOf "." constr of
+stripModulePath constr = case lastIndexOf (Pattern ".") constr of
                     Nothing -> constr
                     Just i -> drop (i+1) constr
 

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -106,8 +106,8 @@ checkAesonCompat =
         Aeson.encodeJson myTuple      == fromArray [fromNumber $ toNumber 1, fromNumber $ toNumber 2, fromString "Hello"]
     &&  Aeson.encodeJson myJust       == fromString "Test"
     &&  Aeson.encodeJson myNothing    == jsonNull
-    &&  Aeson.encodeJson myLeft       == fromObject (SM.fromList (Tuple "Left" (fromString "Foo") `Cons` Nil))
-    &&  Aeson.encodeJson myRight      == fromObject (SM.fromList (Tuple "Right" (fromString "Bar") `Cons` Nil))
+    &&  Aeson.encodeJson myLeft       == fromObject (SM.singleton "Left" (fromString "Foo"))
+    &&  Aeson.encodeJson myRight      == fromObject (SM.singleton "Right" (fromString "Bar"))
     &&  Aeson.encodeJson unwrapMult   == fromArray [fromNumber $ toNumber 8, fromString "haha"]
     &&  Aeson.encodeJson unwrapSingle == (fromNumber $ toNumber 8)
 
@@ -115,7 +115,7 @@ checkRecordEncoding :: forall eff. Eff (assert :: ASSERT | eff) Unit
 checkRecordEncoding = do
     let smallRecord = SmallRecord {foo: "foo", bar: 42}
     let encoded = Aeson.encodeJson smallRecord
-    let expected = fromObject $ SM.fromList $
+    let expected = fromObject $ SM.fromFoldable $
           Tuple "tag" (fromString "SmallRecord") :
           Tuple "foo" (fromString "foo") :
           Tuple "bar" (fromNumber $ toNumber 42) :
@@ -126,10 +126,10 @@ checkRecordEncodingArgonaut :: forall eff. Eff (assert :: ASSERT | eff) Unit
 checkRecordEncodingArgonaut = do
     let smallRecord = SmallRecord {foo: "foo", bar: 42}
     let encoded = Argonaut.encodeJson smallRecord
-    let expected = fromObject $ SM.fromList $
+    let expected = fromObject $ SM.fromFoldable $
           Tuple "tag" (fromString "Test.Main.SmallRecord") :
           Tuple "values"
-            (fromArray [fromObject $ SM.fromList $
+            (fromArray [fromObject $ SM.fromFoldable $
               Tuple "foo" (fromString "foo") :
               Tuple "bar" (fromNumber $ toNumber 42) :
               Nil


### PR DESCRIPTION
This PR updates the dependencies and libraries to work with PureScript 0.10.2 compiler.

I've verified that tests run and pass, though you may want to wait on [this PR](https://github.com/zudov/purescript-strongcheck-generics/pull/6) to be released before merging.