### PR TITLE
Skip contents field when constructor has no arguments (aeson)

### DIFF
--- a/src/Data/Argonaut/Generic/Encode.purs
+++ b/src/Data/Argonaut/Generic/Encode.purs
@@ -75,7 +75,9 @@ genericEncodeProdJson' opts'@(Options opts) constrSigns constr args =
     else case containedRecord of
       Nothing  -> fromObject
                   $ SM.insert sumConf.tagFieldName (fromString fixedConstr)
-                  $ SM.singleton sumConf.contentsFieldName contents
+                  $ if opts.flattenContentsArray && length args == 0
+                    then SM.empty
+                    else SM.singleton sumConf.contentsFieldName contents
       Just obj -> fromObject
                   $ SM.insert sumConf.tagFieldName (fromString fixedConstr) obj
   where

--- a/src/Data/Argonaut/Generic/Options.purs
+++ b/src/Data/Argonaut/Generic/Options.purs
@@ -19,6 +19,7 @@ newtype Options = Options { -- newtype necessary to avoid: https://github.com/pu
   -- | Options on how to do encoding of sum types.
 , sumEncoding             :: SumEncoding
   -- | If a constructor has exactly one field, do not serialize as array.
+  -- | Also, if the constructor has no fields, skip the contents field (aeson >= 1 behavior).
 , flattenContentsArray    :: Boolean -- Flatten array to simple value, if constructor only takes a single value
   -- | You need a newtype wrapper encoding/decoding of records, set this
   --   to false if you want the plain Javascript object without a wrapping tagged object.


### PR DESCRIPTION
Resolves #10.

I did not introduce an extra options field, but use the `flattenContentsArray` setting to distinguish this behavior between argonaut and aeson.