### PR TITLE
Add omitNothingFields option.

### DIFF
--- a/src/Data/Argonaut/Generic/Aeson.purs
+++ b/src/Data/Argonaut/Generic/Aeson.purs
@@ -39,6 +39,7 @@ options = Options {
 , userEncoding             : userEncoding
 , userDecoding             : userDecoding
 , fieldLabelModifier       : id
+, omitNothingFields        : false
 }
 
 sumEncoding :: SumEncoding

--- a/src/Data/Argonaut/Generic/Argonaut.purs
+++ b/src/Data/Argonaut/Generic/Argonaut.purs
@@ -24,6 +24,7 @@ options = Options {
 , userEncoding             : dummyUserEncoding
 , userDecoding             : dummyUserDecoding
 , fieldLabelModifier       : id
+, omitNothingFields        : false
 }
 
 sumEncoding :: SumEncoding

--- a/src/Data/Argonaut/Generic/Options.purs
+++ b/src/Data/Argonaut/Generic/Options.purs
@@ -35,6 +35,9 @@ newtype Options = Options { -- newtype necessary to avoid: https://github.com/pu
 , userDecoding :: Options -> GenericSignature -> Json -> Maybe (Either String GenericSpine)
   -- | Modify a fields label, e.g. convert the case from that used remotely.
   , fieldLabelModifier :: String -> String
+  -- | If True record fields with a Nothing value will be omitted from the resulting object.
+  -- | If False the resulting object will include those fields.
+  , omitNothingFields :: Boolean
 }
 
 data SumEncoding =

--- a/src/Data/Argonaut/Generic/Util.purs
+++ b/src/Data/Argonaut/Generic/Util.purs
@@ -3,9 +3,10 @@ module Data.Argonaut.Generic.Util where
 import Prelude
 import Data.Array (head, null, length)
 import Data.Foldable (all)
-import Data.Generic (GenericSignature(SigRecord), GenericSpine(SRecord), DataConstructor)
+import Data.Generic (DataConstructor, GenericSignature(..), GenericSpine(..), toSignature)
 import Data.Maybe (fromMaybe, Maybe(..))
 import Data.String (lastIndexOf, drop, Pattern(..))
+import Type.Proxy (Proxy(..))
 
 allConstructorsNullary :: Array DataConstructor -> Boolean
 allConstructorsNullary = all (null <<< _.sigValues)
@@ -34,3 +35,15 @@ constructorIsRecord constr = fromMaybe false $ do
   case record of
     SigRecord _ -> pure true
     _ -> pure false
+
+
+sigIsMaybe :: GenericSignature -> Boolean
+sigIsMaybe sig =
+  case sig of
+    SigProd constructor _ -> constructor == maybeConstructor
+    _ -> false
+  where
+    maybeConstructor =
+        case toSignature (Proxy :: Proxy (Maybe Int)) of
+          (SigProd constructor _) -> constructor
+          _ -> ""


### PR DESCRIPTION
Some APIs prefer empty fields to be omitted from JSON objects, rather than set
to null.

This commit adds an omitNothingFields option to handle this.  If this option is
set to true, a Nothing field inside of a record will be omitted from the
resulting JSON object.