### PR TITLE
Update dependencies for psc 0.11.3

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,10 +23,10 @@
   },
   "license": "MIT",
   "dependencies": {
-    "purescript-argonaut-core": "^2.0.1",
-    "purescript-arrays": "^3.1.0",
-    "purescript-generics": "^3.1.0",
-    "purescript-integers": "^2.1.0",
+    "purescript-argonaut-core": "^3.1.0",
+    "purescript-arrays": "^4.0.0",
+    "purescript-generics": "^4.0.0",
+    "purescript-integers": "^3.0.0",
     "purescript-partial": "^1.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
`"purescript-strongcheck-generics": "^0.5.0"` still causes problems but is defined in dev dependencies.